### PR TITLE
Include openai in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 faiss_cpu==1.7.3
 langchain==0.0.136
 pydantic==1.10.7
+openai==0.27.4


### PR DESCRIPTION
This fixes the out-of-the-box error:

```
What is my purpose? You are going to ...
Traceback (most recent call last):
  File "/home/jacob/.pyenv/versions/3.10.9/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/home/jacob/.pyenv/versions/3.10.9/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/jacob/github/autolang/autolang/__main__.py", line 15, in <module>
    llm: BaseLLM = ChatOpenAI(model_name="gpt-4", temperature=0, request_timeout=120) # type: ignore 
  File "pydantic/main.py", line 341, in pydantic.main.BaseModel.__init__
pydantic.error_wrappers.ValidationError: 1 validation error for ChatOpenAI
__root__
  Could not import openai python package. Please it install it with `pip install openai`. (type=value_error)
```